### PR TITLE
add option to raise an exception if vcr is used and it's not needed

### DIFF
--- a/vcr/core.py
+++ b/vcr/core.py
@@ -81,11 +81,15 @@ class VCRSystem(object):
     ``recv_size`` : int
         Will request given number of bytes in socket recv calls. Option is
         ignored if not set (default).
+    ``raise_if_not_needed`` : bool
+        Raise if vcr decorator is not needed because no socket traffic is
+        recorded, instead of just showing a warning.
     """
     debug = False
     disabled = False
     overwrite = False
     playback_only = False
+    raise_if_not_needed = False
     recv_timeout = 5
     recv_endmarkers = []
     recv_size = None
@@ -494,7 +498,11 @@ def vcr(decorated_func=None, debug=False, overwrite=False, disabled=False,
                 # write to file
                 if len(VCRSystem.playlist) == 0:
                     msg = 'no socket activity - @vcr decorator unneeded for %s'
-                    warnings.warn(msg % (func.__name__))
+                    msg = msg % func.__name__
+                    if VCRSystem.raise_if_not_needed:
+                        raise Exception(msg)
+                    else:
+                        warnings.warn(msg)
                 else:
                     with open(tape, 'wb') as fh:
                         pickle.dump(VCRSystem.playlist, fh, protocol=2)


### PR DESCRIPTION
This way it becomes more obvious if decorator is used where it should not be.. otherwise it's sometimes hard to know why tape files are not generated for decorated functions when the warning message is suppressed..

In obspy this can then look like:
```
$ obspy-runtests clients.fdsn --vcr-record
Running /home/megies/git/obspy-master/obspy/scripts/runtests.py, ObsPy version '1.0.3.post0+1008.g2485130a56.dirty.obspy.vcr'
...............E........................................................

======================================================================
ERROR: test_manually_deactivate_single_service (obspy.clients.fdsn.tests.test_client.ClientTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "<decorator-gen-54>", line 2, in test_manually_deactivate_single_service
  File "/home/megies/git/obspy-master/obspy/core/util/decorator.py", line 87, in vcr
    decorated_func=func, raise_if_not_needed=True)(*args, **kwargs)
  File "/home/megies/git/vcr/vcr/core.py", line 498, in _vcr_inner
    raise Exception(msg)
Exception: no socket activity - @vcr decorator unneeded for test_manually_deactivate_single_service

----------------------------------------------------------------------
Ran 72 tests in 94.194s

FAILED (errors=1)
Do you want to report this to tests.obspy.org? [n]: 
```

Otherwise test passes without a VCR tape generated and it's not immediately obvious what's going wrong..